### PR TITLE
Updated docs for DefineMap methods

### DIFF
--- a/docs/can-define-stream.md
+++ b/docs/can-define-stream.md
@@ -55,10 +55,9 @@ me.last = "Ahmed"; //-> console.logs 2
 The [can-define-stream.toStream] method has shorthands for all of the other methods:
 
 ```js
-toStream(compute)                    //-> stream
-toStream(map, "eventName")           //-> stream
-toStream(map, ".propName")           //-> stream
-toStream(map, ".propName eventName") //-> stream
+toStream("eventName")           //-> stream
+toStream(".propName")           //-> stream
+toStream(".propName eventName") //-> stream
 ```
 
 For example:
@@ -66,6 +65,7 @@ For example:
 __Update map property based on stream value__
 
 ```js
+var DefineMap = require('can-define/map/map');
 var canStream = require("can-stream-kefir");
 var canDefineStream = require("can-define-stream");
 
@@ -93,6 +93,7 @@ me.name = "James Atherton"; //lastValidName -> James Atherton
 __Stream on DefineList__
 
 ```js
+var DefineList = require('can-define/list/list');
 var canStream = require("can-stream-kefir");
 var canDefineStream = require("can-define-stream");
 

--- a/docs/methods.toCompute.md
+++ b/docs/methods.toCompute.md
@@ -1,13 +1,12 @@
 @function can-define-stream.tocompute toCompute
 @parent can-define-stream.fns
 
+@description Create a compute that gets updated whenever the stream value changes.
 
-@description Creates a compute that gets updated whenever the stream value changes.
+@signature `DefineMap.toCompute( stream )`
 
-@signature `canStream.toCompute( stream )`
+Creates a compute that gets updated whenever the stream value changes.
 
-Creates a compute that gets updated whenever the stream value changes.s
-
-@param {can-stream} a streams
+@param {can-stream} stream A [can-stream] stream
 
 @return {can-compute} A [can-compute] compute.

--- a/docs/methods.toStream.md
+++ b/docs/methods.toStream.md
@@ -1,12 +1,42 @@
 @function can-define-stream.toStream toStream
 @parent can-define-stream.fns
 
-@description Creates a stream based on [can-compute] compute
+@description Provide a shorthand for creating a stream on properties and/or events.
 
-@signature `canStream.toStream( propAndOrEvent )`
+@signature `DefineMap.toStream( propAndOrEvent[,event] )`
 
 Creates a stream that gets updated whenever the property value changes or event is triggered.
 
-@param {String} an event or property name
+```js
+var DefineMap = require('can-define/map/map');
+var canStream = require("can-stream-kefir");
+var canDefineStream = require("can-define-stream");
 
-@return {Stream} A [can-stream](https://github.com/canjs/can-stream) stream.
+var Person = DefineMap.extend({
+    name: "string",
+    lastValidName: {
+        stream: function() {
+            return this.toStream(".name").filter(function(name) { // using propName
+                return name.indexOf(" ") >= 0;
+            });
+        }
+    }
+});
+
+canDefineStream(canStream)(Person);
+
+var me = new Person({name: "James"});
+
+me.on("lastValidName", function(lastValid) {});
+
+me.name = "JamesAtherton"; //lastValidName -> undefined
+me.name = "James Atherton"; //lastValidName -> James Atherton
+```
+
+@param {String} prop A property name prepended by a dot '.prop'
+
+@param {String} event An event name 'event'
+
+@param {String} propAndEvent A property name prepended by a dot follow by an event name seperated by a space '.prop event'
+
+@return {Stream} A [can-stream] stream.

--- a/docs/methods.toStreamFromEvent.md
+++ b/docs/methods.toStreamFromEvent.md
@@ -6,7 +6,7 @@
 
 @signature `DefineMap.toStreamFromEvent( eventName )`
 
-Creates a stream from a that gets updated whenever the event is triggered.
+Creates a stream from an event that gets updated whenever the event is triggered.
 
 ```js
 var DefineList = require('can-define/list/list');
@@ -22,7 +22,7 @@ var people = new PeopleList([
     { first: "Paula", last: "Strozak" }
 ]);
 
-var stream = people.toStream('length'); // using eventName
+var stream = people.toStreamFromEvent('length'); // using eventName
 
 stream.onValue(function(val) {
     val //-> 2, 3

--- a/docs/methods.toStreamFromEvent.md
+++ b/docs/methods.toStreamFromEvent.md
@@ -2,12 +2,38 @@
 @parent can-define-stream.fns
 
 
-@description Creates a stream based on event
+@description Create a stream based on an event
 
-@signature `canStream.toStreamFromEvent( eventName )`
+@signature `DefineMap.toStreamFromEvent( eventName )`
 
 Creates a stream from a that gets updated whenever the event is triggered.
 
-@param {String} an event name
+```js
+var DefineList = require('can-define/list/list');
+var canStream = require("can-stream-kefir");
+var canDefineStream = require("can-define-stream");
 
-@return {Stream} A [can-stream](https://github.com/canjs/can-stream) stream.
+var PeopleList = DefineList.extend({});
+
+canDefineStream(canStream)(PeopleList);
+
+var people = new PeopleList([
+    { first: "Justin", last: "Meyer" },
+    { first: "Paula", last: "Strozak" }
+]);
+
+var stream = people.toStream('length'); // using eventName
+
+stream.onValue(function(val) {
+    val //-> 2, 3
+});
+
+people.push({
+    first: 'Obaid',
+    last: 'Ahmed'
+}); //-> stream.onValue -> 3
+```
+
+@param {String} event An event name
+
+@return {Stream} A [can-stream] stream.

--- a/docs/methods.toStreamFromProperty.md
+++ b/docs/methods.toStreamFromProperty.md
@@ -1,13 +1,38 @@
 @function can-define-stream.tostreamfromproperty toStreamFromProperty
 @parent can-define-stream.fns
 
+@description Create a stream based on a property
 
-@description Creates a stream based on property
+@signature `DefineMap.toStreamFromProperty( property )`
 
-@signature `canStream.toStreamFromProperty( property )`
+Creates a stream from a property that gets updated whenever the property value changes.
 
-Creates a stream from a that gets updated whenever the property value changes.
+```js
+var DefineMap = require('can-define/map/map');
+var canStream = require("can-stream-kefir");
+var canDefineStream = require("can-define-stream");
 
-@param {String} a property name
+var Person = DefineMap.extend({
+    name: "string",
+    lastValidName: {
+        stream: function() {
+            return this.toStream(".name").filter(function(name) { // using propName
+                return name.indexOf(" ") >= 0;
+            });
+        }
+    }
+});
 
-@return {Stream} A [can-stream](https://github.com/canjs/can-stream) stream.
+canDefineStream(canStream)(Person);
+
+var me = new Person({name: "James"});
+
+me.on("lastValidName", function(lastValid) {});
+
+me.name = "JamesAtherton"; //lastValidName -> undefined
+me.name = "James Atherton"; //lastValidName -> James Atherton
+```
+
+@param {String} property A property name
+
+@return {Stream} A [can-stream] stream.

--- a/docs/methods.toStreamFromProperty.md
+++ b/docs/methods.toStreamFromProperty.md
@@ -16,7 +16,7 @@ var Person = DefineMap.extend({
     name: "string",
     lastValidName: {
         stream: function() {
-            return this.toStream(".name").filter(function(name) { // using propName
+            return this.toStreamFromProperty(".name").filter(function(name) { // using propName
                 return name.indexOf(" ") >= 0;
             });
         }
@@ -33,6 +33,6 @@ me.name = "JamesAtherton"; //lastValidName -> undefined
 me.name = "James Atherton"; //lastValidName -> James Atherton
 ```
 
-@param {String} property A property name
+@param {String} property A property name prepended by a dot. '.prop'
 
 @return {Stream} A [can-stream] stream.

--- a/docs/types.streamInterface.md
+++ b/docs/types.streamInterface.md
@@ -3,7 +3,7 @@
 
 @description A [can-stream.types.streamInterface] function.
 
-@signature `streamInterface(observable, propAndOrEvent[,event])`
+@signature `streamInterface([observable], propAndOrEvent[,event])`
 
 The stream interface function returned from [can-stream] that will be used to add streamable props to a provided [can-define-stream.types.DefineMap DefineMap.prototype] or [can-define-stream.types.DefineList DefineList.prototype] and has the following property methods:
 


### PR DESCRIPTION
Updated docs for the `DefineMap methods` group to reflect how they are added and used.

It looks like `toCompute` is not getting added to the `DefineMap.prototype` correctly.